### PR TITLE
Curated project bot refactor

### DIFF
--- a/CuratedProjectBot.js
+++ b/CuratedProjectBot.js
@@ -22,6 +22,7 @@ class CuratedProjectBot {
 
   async getData(msg, number) {
     let pieceNumber = parseInt(number.substring(1));
+
     if (pieceNumber >= this.editionNumber || pieceNumber < 0) {
       msg.channel.send(
         `Invalid #, only ${this.editionNumber} pieces minted for ${this.projectName}.`
@@ -110,17 +111,31 @@ class CuratedProjectBot {
     let ownerUsername = ownerAccount.user !== null ?
       ownerAccount.user.username :
       UNKNOWN_USERNAME;
-    if (ownerUsername === null) { ownerUsername = UNKNOWN_USERNAME; }
+    if (ownerAccount !== null) {
+      ownerAddress = ownerAccount.address;
+      ownerAddressPreview = ownerAddress !== null ?
+        ownerAddress.slice(0, 8) :
+        UNKNOWN_ADDRESS;
+      ownerUsername = ownerAccount.user !== null ?
+        ownerAccount.user.username :
+        UNKNOWN_USERNAME;
+      if (ownerUsername === null) { ownerUsername = UNKNOWN_USERNAME; }
+    }
 
     let fromAccount = eventData.from_account;
-    let fromAddress = fromAccount.address;
-    let fromAddressPreview = fromAddress !== null ?
-      fromAddress.slice(0, 8) :
-      UNKNOWN_ADDRESS;
-    let fromUsername = fromAccount.user !== null ?
-      fromAccount.user.username :
-      UNKNOWN_USERNAME;
-    if (fromUsername === null) { fromUsername = UNKNOWN_USERNAME; }
+    let fromAddress;
+    let fromAddressPreview;
+    let fromUsername;
+    if (fromAccount !== null) {
+      fromAddress = fromAccount.address;
+      fromAddressPreview = fromAddress !== null ?
+        fromAddress.slice(0, 8) :
+        UNKNOWN_ADDRESS;
+      fromUsername = fromAccount.user !== null ?
+        fromAccount.user.username :
+        UNKNOWN_USERNAME;
+      if (fromUsername === null) { fromUsername = UNKNOWN_USERNAME; }
+    }
 
     switch (eventType) {
       case "created":

--- a/CuratedProjectBot.js
+++ b/CuratedProjectBot.js
@@ -1,0 +1,195 @@
+require("dotenv").config();
+const {
+  MessageEmbed
+} = require("discord.js");
+const fetch = require("node-fetch");
+const Web3 = require("web3");
+
+let web3 = new Web3(Web3.givenProvider || "ws://localhost:8545");
+
+const MINT_ADDRESS = "0x0000000000000000000000000000000000000000";
+const EMBED_COLOR = 0xff0000;
+const UNKNOWN_ADDRESS = "unknown";
+const UNKNOWN_USERNAME = "unknown";
+
+class CuratedProjectBot {
+  constructor(projectNumber, mintContract, editionNumber, projectName) {
+    this.projectNumber = projectNumber;
+    this.mintContract = mintContract;
+    this.editionNumber = editionNumber;
+    this.projectName = projectName;
+  }
+
+  async getData(msg, number) {
+    let pieceNumber = parseInt(number.substring(1));
+    if (pieceNumber >= this.editionNumber || pieceNumber < 0) {
+      msg.channel.send(
+        `Invalid #, only ${this.editionNumber} pieces minted for ${this.projectName}.`
+      );
+      return;
+    }
+
+    let tokenNumber = pieceNumber + this.projectNumber;
+    let openSeaURL = `https://api.opensea.io/api/v1/events?asset_contract_address=${this.mintContract}&token_id=${tokenNumber}&only_opensea=false&offset=0&limit=5`;
+
+    await fetch(
+        openSeaURL, {
+          method: "GET",
+          headers: {},
+        }
+      )
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data, "OPENSEA DATA");
+        let eventData = data.asset_events[0];
+        this.metaData(eventData, msg, tokenNumber);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  async metaData(eventData, msg, url) {
+    let artBlocksResponse = await fetch(`https://api.artblocks.io/token/${url}`);
+    let artBlocksData = await artBlocksResponse.json();
+    console.log(artBlocksData, "ARTBLOCKS DATA");
+
+    const embedContent = new MessageEmbed()
+      // Set the title of the field.
+      .setTitle(eventData.asset.name)
+      // Add link to OpenSea listing.
+      .setURL(eventData.asset.permalink)
+      // Set the color of the embed.
+      .setColor(EMBED_COLOR)
+      // Set the main content of the embed
+      .setThumbnail(eventData.asset.image_url)
+      // Add "Live Script" field.
+      .addField("Live Script", `[view on artblocks.io](${artBlocksData.external_url})`)
+      // Add "Features" field.
+      .addField("Features", `${artBlocksData.features.join("\n")}`)
+      // Add current owner info.
+      .addFields(this.parseOwnerInfo(eventData.asset.owner))
+      // Add most recent event info.
+      .addFields(
+        eventData.event_type !== null ?
+        this.parseEventInfo(eventData) : {
+          name: "Last Sale",
+          value: "No Transactions"
+        }
+      );
+    msg.channel.send(embedContent);
+  }
+
+  parseOwnerInfo(ownerAccount) {
+    let address = ownerAccount.address;
+    let addressPreview = address !== null ?
+      address.slice(0, 8) :
+      UNKNOWN_ADDRESS;
+    let addressOpenSeaURL = `https://opensea.io/accounts/${address}`;
+    let ownerUsername = ownerAccount.user !== null ?
+      ownerAccount.user.username :
+      UNKNOWN_USERNAME;
+    if (ownerUsername === null) { ownerUsername = UNKNOWN_USERNAME; }
+
+    return {
+      name: "Owner",
+      value: `[${addressPreview}](${addressOpenSeaURL}) (${ownerUsername})`,
+      inline: true,
+    };
+  }
+
+  parseEventInfo(eventData) {
+    let eventType = eventData.event_type;
+    let eventDate = new Date(eventData.created_date).toLocaleDateString();
+
+    let ownerAccount = eventData.asset.owner;
+    let ownerAddress = ownerAccount.address;
+    let ownerAddressPreview = ownerAddress !== null ?
+      ownerAddress.slice(0, 8) :
+      UNKNOWN_ADDRESS;
+    let ownerUsername = ownerAccount.user !== null ?
+      ownerAccount.user.username :
+      UNKNOWN_USERNAME;
+    if (ownerUsername === null) { ownerUsername = UNKNOWN_USERNAME; }
+
+    let fromAccount = eventData.from_account;
+    let fromAddress = fromAccount.address;
+    let fromAddressPreview = fromAddress !== null ?
+      fromAddress.slice(0, 8) :
+      UNKNOWN_ADDRESS;
+    let fromUsername = fromAccount.user !== null ?
+      fromAccount.user.username :
+      UNKNOWN_USERNAME;
+    if (fromUsername === null) { fromUsername = UNKNOWN_USERNAME; }
+
+    switch (eventType) {
+      case "created":
+        return {
+          name: "Offered At",
+          value: ` ${web3.utils.fromWei(
+                  eventData.ending_price,
+                  "ether"
+                )}Ξ on ${eventDate}`,
+          inline: true,
+        };
+
+      case "successful":
+        return {
+          name: "Last Sale",
+          value: `Sold for ${web3.utils.fromWei(
+                  eventData.total_price,
+                  "ether"
+                )}Ξ on ${eventDate}`,
+          inline: true,
+        };
+
+      case "transfer":
+        if (fromAddress == MINT_ADDRESS) {
+          return {
+            name: "Minted On:",
+            value: `${eventDate}`,
+            inline: true,
+          };
+        }
+        return {
+          name: "Recent Transfer",
+          value: `From [${fromAddressPreview}](https://opensea.io/accounts/${
+                        fromAddress
+                      }) (${fromUsername}) on ${eventDate}`,
+          inline: true,
+        };
+
+      case "bid_withdrawn":
+        return {
+          name: "Bid Withdrawn",
+          value: ` ${web3.utils.fromWei(
+                    eventData.total_price,
+                    "ether"
+                  )}Ξ from [${fromAddressPreview}](https://opensea.io/accounts/${fromAddress}) (${fromUsername}) on ${eventDate}`,
+          inline: true,
+        };
+
+      case "cancelled":
+        return {
+          name: "Canceled Offer",
+          value: ` ${web3.utils.fromWei(
+                  eventData.total_price,
+                  "ether"
+                )}Ξ from [${ownerAddressPreview}](https://opensea.io/accounts/${ownerAddress}) (${ownerUsername}) on ${eventDate}`,
+          inline: true,
+        };
+
+      default:
+        return {
+          name: "Current Bid",
+          value: ` ${web3.utils.fromWei(
+                  eventData.bid_amount,
+                  "ether"
+                )}Ξ from [${fromAddressPreview}](https://opensea.io/accounts/${fromAddress}) (${fromUsername}) on ${eventDate}`,
+          inline: true,
+        }
+    }
+  }
+}
+
+module.exports.CuratedProjectBot = CuratedProjectBot;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const os = require("./osEvent");
 const ignition = require("./ignition");
 const squig = require("./squiggle");
 const ringers = require("./ringers");
+const CuratedProjectBot = require("./CuratedProjectBot").CuratedProjectBot;
 
 let web3 = new Web3(Web3.givenProvider || "ws://localhost:8545");
 
@@ -207,6 +208,13 @@ bot.on("ready", () => {
   console.info(`Logged in as ${bot.user.tag}!`);
 });
 
+let ringersBot = new CuratedProjectBot(
+  13000000,
+  "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
+  1000,
+  "Ringers"
+)
+
 bot.on("message", (msg) => {
   if (msg.content.startsWith("#")) {
     if (msg.channel.id === CHANNEL_SING) {
@@ -219,7 +227,7 @@ bot.on("message", (msg) => {
       squig.squigData(msg, msg.content);
     }
     if (msg.channel.id === CHANNEL_RINGERS) {
-      ringers.ringerData(msg, msg.content);
+      ringersBot.getData(msg, msg.content);
     }
   }
 });

--- a/ringers.js
+++ b/ringers.js
@@ -25,8 +25,8 @@ async function metaData(data, msg, url) {
     .setColor(0xff0000)
     // Set the main content of the embed
     .setThumbnail(data.asset.image_url)
-    .addField("Features", `[view on artblocks.io](${abData.external_url})`)
-    .addField("Live Script", `${abData.features.join("\n")}`)
+    .addField("Live Script", `[view on artblocks.io](${abData.external_url})`)
+    .addField("Features", `${abData.features.join("\n")}`)
     // .addFields({
     //   name: "Features",
     //   value: featureData,


### PR DESCRIPTION
Refactored and generalized logic from Ringers bot into a new class `CuratedProjectBot`, and migrated the concrete Ringers bot to make use of this class rather than using `ringers.js`.

Note I am not yet at this time deleting `ringers.js`, opting instead to delete this file and all unused project specific bots that can be replaced by this abstraction in a follow on PR, after all existing bots are migrated.

This PR also fixes some minor issues in the process of cleaning up the logic in the new shared `CuratedProjectBot`. For example, [Ringer #789](https://artblocks.io/token/13000789) now properly loads in the bot where it didn't before:

<img width="867" alt="Screen Shot 2021-02-22 at 11 10 45 PM" src="https://user-images.githubusercontent.com/8602661/108808199-56003b80-7563-11eb-832f-4cc5cfd8bdd2.png">
