### PR TITLE
Curated project bot migration

### DIFF
--- a/CuratedProjectBot.js
+++ b/CuratedProjectBot.js
@@ -1,0 +1,195 @@
+require("dotenv").config();
+const {
+  MessageEmbed
+} = require("discord.js");
+const fetch = require("node-fetch");
+const Web3 = require("web3");
+
+let web3 = new Web3(Web3.givenProvider || "ws://localhost:8545");
+
+const MINT_ADDRESS = "0x0000000000000000000000000000000000000000";
+const EMBED_COLOR = 0xff0000;
+const UNKNOWN_ADDRESS = "unknown";
+const UNKNOWN_USERNAME = "unknown";
+
+class CuratedProjectBot {
+  constructor(projectNumber, mintContract, editionNumber, projectName) {
+    this.projectNumber = projectNumber;
+    this.mintContract = mintContract;
+    this.editionNumber = editionNumber;
+    this.projectName = projectName;
+  }
+
+  async getData(msg, number) {
+    let pieceNumber = parseInt(number.substring(1));
+    if (pieceNumber >= this.editionNumber || pieceNumber < 0) {
+      msg.channel.send(
+        `Invalid #, only ${this.editionNumber} pieces minted for ${this.projectName}.`
+      );
+      return;
+    }
+
+    let tokenNumber = pieceNumber + this.projectNumber;
+    let openSeaURL = `https://api.opensea.io/api/v1/events?asset_contract_address=${this.mintContract}&token_id=${tokenNumber}&only_opensea=false&offset=0&limit=5`;
+
+    await fetch(
+        openSeaURL, {
+          method: "GET",
+          headers: {},
+        }
+      )
+      .then((response) => response.json())
+      .then((data) => {
+        console.log(data, "OPENSEA DATA");
+        let eventData = data.asset_events[0];
+        this.metaData(eventData, msg, tokenNumber);
+      })
+      .catch((err) => {
+        console.error(err);
+      });
+  }
+
+  async metaData(eventData, msg, url) {
+    let artBlocksResponse = await fetch(`https://api.artblocks.io/token/${url}`);
+    let artBlocksData = await artBlocksResponse.json();
+    console.log(artBlocksData, "ARTBLOCKS DATA");
+
+    const embedContent = new MessageEmbed()
+      // Set the title of the field.
+      .setTitle(eventData.asset.name)
+      // Add link to OpenSea listing.
+      .setURL(eventData.asset.permalink)
+      // Set the color of the embed.
+      .setColor(EMBED_COLOR)
+      // Set the main content of the embed
+      .setThumbnail(eventData.asset.image_url)
+      // Add "Live Script" field.
+      .addField("Live Script", `[view on artblocks.io](${artBlocksData.external_url})`)
+      // Add "Features" field.
+      .addField("Features", `${artBlocksData.features.join("\n")}`)
+      // Add current owner info.
+      .addFields(this.parseOwnerInfo(eventData.asset.owner))
+      // Add most recent event info.
+      .addFields(
+        eventData.event_type !== null ?
+        this.parseEventInfo(eventData) : {
+          name: "Last Sale",
+          value: "No Transactions"
+        }
+      );
+    msg.channel.send(embedContent);
+  }
+
+  parseOwnerInfo(ownerAccount) {
+    let address = ownerAccount.address;
+    let addressPreview = address !== null ?
+      address.slice(0, 8) :
+      UNKNOWN_ADDRESS;
+    let addressOpenSeaURL = `https://opensea.io/accounts/${address}`;
+    let ownerUsername = ownerAccount.user !== null ?
+      ownerAccount.user.username :
+      UNKNOWN_USERNAME;
+    if (ownerUsername === null) { ownerUsername = UNKNOWN_USERNAME; }
+
+    return {
+      name: "Owner",
+      value: `[${addressPreview}](${addressOpenSeaURL}) (${ownerUsername})`,
+      inline: true,
+    };
+  }
+
+  parseEventInfo(eventData) {
+    let eventType = eventData.event_type;
+    let eventDate = new Date(eventData.created_date).toLocaleDateString();
+
+    let ownerAccount = eventData.asset.owner;
+    let ownerAddress = ownerAccount.address;
+    let ownerAddressPreview = ownerAddress !== null ?
+      ownerAddress.slice(0, 8) :
+      UNKNOWN_ADDRESS;
+    let ownerUsername = ownerAccount.user !== null ?
+      ownerAccount.user.username :
+      UNKNOWN_USERNAME;
+    if (ownerUsername === null) { ownerUsername = UNKNOWN_USERNAME; }
+
+    let fromAccount = eventData.from_account;
+    let fromAddress = fromAccount.address;
+    let fromAddressPreview = fromAddress !== null ?
+      fromAddress.slice(0, 8) :
+      UNKNOWN_ADDRESS;
+    let fromUsername = fromAccount.user !== null ?
+      fromAccount.user.username :
+      UNKNOWN_USERNAME;
+    if (fromUsername === null) { fromUsername = UNKNOWN_USERNAME; }
+
+    switch (eventType) {
+      case "created":
+        return {
+          name: "Offered At",
+          value: ` ${web3.utils.fromWei(
+                  eventData.ending_price,
+                  "ether"
+                )}Ξ on ${eventDate}`,
+          inline: true,
+        };
+
+      case "successful":
+        return {
+          name: "Last Sale",
+          value: `Sold for ${web3.utils.fromWei(
+                  eventData.total_price,
+                  "ether"
+                )}Ξ on ${eventDate}`,
+          inline: true,
+        };
+
+      case "transfer":
+        if (fromAddress == MINT_ADDRESS) {
+          return {
+            name: "Minted On:",
+            value: `${eventDate}`,
+            inline: true,
+          };
+        }
+        return {
+          name: "Recent Transfer",
+          value: `From [${fromAddressPreview}](https://opensea.io/accounts/${
+                        fromAddress
+                      }) (${fromUsername}) on ${eventDate}`,
+          inline: true,
+        };
+
+      case "bid_withdrawn":
+        return {
+          name: "Bid Withdrawn",
+          value: ` ${web3.utils.fromWei(
+                    eventData.total_price,
+                    "ether"
+                  )}Ξ from [${fromAddressPreview}](https://opensea.io/accounts/${fromAddress}) (${fromUsername}) on ${eventDate}`,
+          inline: true,
+        };
+
+      case "cancelled":
+        return {
+          name: "Canceled Offer",
+          value: ` ${web3.utils.fromWei(
+                  eventData.total_price,
+                  "ether"
+                )}Ξ from [${ownerAddressPreview}](https://opensea.io/accounts/${ownerAddress}) (${ownerUsername}) on ${eventDate}`,
+          inline: true,
+        };
+
+      default:
+        return {
+          name: "Current Bid",
+          value: ` ${web3.utils.fromWei(
+                  eventData.bid_amount,
+                  "ether"
+                )}Ξ from [${fromAddressPreview}](https://opensea.io/accounts/${fromAddress}) (${fromUsername}) on ${eventDate}`,
+          inline: true,
+        }
+    }
+  }
+}
+
+module.exports.CuratedProjectBot = CuratedProjectBot;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const os = require("./osEvent");
 const ignition = require("./ignition");
 const squig = require("./squiggle");
 const ringers = require("./ringers");
+const CuratedProjectBot = require("./CuratedProjectBot").CuratedProjectBot;
 
 let web3 = new Web3(Web3.givenProvider || "ws://localhost:8545");
 
@@ -207,6 +208,13 @@ bot.on("ready", () => {
   console.info(`Logged in as ${bot.user.tag}!`);
 });
 
+let ringersBot = new CuratedProjectBot(
+  13000000,
+  "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
+  1000,
+  "Ringers"
+)
+
 bot.on("message", (msg) => {
   if (msg.content.startsWith("#")) {
     if (msg.channel.id === CHANNEL_SING) {
@@ -219,7 +227,7 @@ bot.on("message", (msg) => {
       squig.squigData(msg, msg.content);
     }
     if (msg.channel.id === CHANNEL_RINGERS) {
-      ringers.ringerData(msg, msg.content);
+      ringersBot.getData(msg, msg.content);
     }
   }
 });

--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
 require("dotenv").config();
-const { Client, MessageEmbed } = require("discord.js");
+const {
+  Client,
+  MessageEmbed
+} = require("discord.js");
 const Web3 = require("web3");
 const express = require("express");
 const bodyParser = require("body-parser");
@@ -13,7 +16,9 @@ const CHANNEL_SQUIG = process.env.CHANNEL_SQUIG;
 const CHANNEL_RINGERS = process.env.CHANNEL_RINGERS;
 const SERVER = process.env.SERVER;
 
-const { init } = require("./singularity");
+const {
+  init
+} = require("./singularity");
 const os = require("./osEvent");
 const ignition = require("./ignition");
 const squig = require("./squiggle");
@@ -29,21 +34,25 @@ const PORT = process.env.PORT || 3000;
 
 app.use(bodyParser.json());
 
-app.post("/update", function (req, res) {
+app.post("/update", function(req, res) {
   console.log("received update with body:\n", JSON.stringify(req.body, null, 2), "\n");
 
   res.setHeader("Content-Type", "application/json");
-  res.json({ success: true });
+  res.json({
+    success: true
+  });
 });
 
-app.get("/update", function (req, res) {
+app.get("/update", function(req, res) {
   console.log("received get with body:\n", req.body, "\n");
 
   res.setHeader("Content-Type", "application/json");
-  res.json({ success: true });
+  res.json({
+    success: true
+  });
 });
 
-app.listen(PORT, function () {
+app.listen(PORT, function() {
   console.log("Server is listening on port ", PORT);
 });
 
@@ -84,35 +93,28 @@ async function metaData(data, msg, url) {
     })
 
     .addFields(
-      data.event_type
-        ? data.event_type == "created"
-          ? {
-              name: "Offered At",
-              value: ` ${web3.utils.fromWei(
+      data.event_type ?
+      data.event_type == "created" ? {
+        name: "Offered At",
+        value: ` ${web3.utils.fromWei(
                 data.ending_price,
                 "ether"
               )}Ξ on ${new Date(data.created_date).toLocaleDateString()}`,
-              inline: true,
-            }
-          : data.event_type == "successful"
-          ? {
-              name: "Last Sale",
-              value: `Sold for ${web3.utils.fromWei(
+        inline: true,
+      } :
+      data.event_type == "successful" ? {
+        name: "Last Sale",
+        value: `Sold for ${web3.utils.fromWei(
                 data.total_price,
                 "ether"
               )}Ξ on ${new Date(data.created_date).toLocaleDateString()}`,
-              inline: true,
-            }
-          : data.event_type == "transfer"
-          ? {
-              name:
-                data.from_account.address == mintAddress
-                  ? "Minted On:"
-                  : "Recent Transfer",
-              value:
-                data.from_account.address == mintAddress
-                  ? new Date(data.created_date).toLocaleDateString()
-                  : `From [${data.from_account.address.slice(
+        inline: true,
+      } :
+      data.event_type == "transfer" ? {
+        name: data.from_account.address == mintAddress ?
+          "Minted On:" : "Recent Transfer",
+        value: data.from_account.address == mintAddress ?
+          new Date(data.created_date).toLocaleDateString() : `From [${data.from_account.address.slice(
                       0,
                       8
                     )}](https://opensea.io/accounts/${
@@ -122,12 +124,11 @@ async function metaData(data, msg, url) {
                         ? `(${data.from_account.user.username.slice(0, 10)})`
                         : ""
                     } on ${new Date(data.created_date).toLocaleDateString()}`,
-              inline: true,
-            }
-          : data.event_type == "bid_withdrawn"
-          ? {
-              name: "Bid Withdrawn",
-              value: ` ${web3.utils.fromWei(
+        inline: true,
+      } :
+      data.event_type == "bid_withdrawn" ? {
+        name: "Bid Withdrawn",
+        value: ` ${web3.utils.fromWei(
                 data.total_price,
                 "ether"
               )}Ξ from [${data.from_account.address.slice(
@@ -138,12 +139,11 @@ async function metaData(data, msg, url) {
                   ? `(${data.from_account.user.usernameslice(0, 10)})`
                   : ""
               }  on ${new Date(data.created_date).toLocaleDateString()}`,
-              inline: true,
-            }
-          : data.event_type == "cancelled"
-          ? {
-              name: "Cancelled Offer",
-              value: ` ${web3.utils.fromWei(
+        inline: true,
+      } :
+      data.event_type == "cancelled" ? {
+        name: "Cancelled Offer",
+        value: ` ${web3.utils.fromWei(
                 data.total_price,
                 "ether"
               )}Ξ from [${data.asset.owner.address.slice(
@@ -154,11 +154,10 @@ async function metaData(data, msg, url) {
                   ? `(${data.asset.owner.user.username})`
                   : ""
               }  on ${new Date(data.created_date).toLocaleDateString()}`,
-              inline: true,
-            }
-          : {
-              name: "Current Bid",
-              value: ` ${web3.utils.fromWei(
+        inline: true,
+      } : {
+        name: "Current Bid",
+        value: ` ${web3.utils.fromWei(
                 data.bid_amount,
                 "ether"
               )}Ξ from [${data.from_account.address.slice(
@@ -169,9 +168,11 @@ async function metaData(data, msg, url) {
                   ? `(${data.from_account.user.username})`
                   : ""
               }  on ${new Date(data.created_date).toLocaleDateString()}`,
-              inline: true,
-            }
-        : { name: "Last Sale", value: "No Transactions" }
+        inline: true,
+      } : {
+        name: "Last Sale",
+        value: "No Transactions"
+      }
     );
 
   msg.channel.send(_embed);
@@ -186,13 +187,13 @@ async function singData(msg, number) {
   }
 
   await fetch(
-    `https://api.opensea.io/api/v1/events?asset_contract_address=${_contract}&token_id=${_token}&only_opensea=false&offset=0&limit=5`,
+      `https://api.opensea.io/api/v1/events?asset_contract_address=${_contract}&token_id=${_token}&only_opensea=false&offset=0&limit=5`,
 
-    {
-      method: "GET",
-      headers: {},
-    }
-  )
+      {
+        method: "GET",
+        headers: {},
+      }
+    )
     .then((response) => response.json())
     .then((data) => {
       let event = data.asset_events[0];
@@ -208,26 +209,49 @@ bot.on("ready", () => {
   console.info(`Logged in as ${bot.user.tag}!`);
 });
 
+let singularityBot = new CuratedProjectBot(
+  8000000,
+  "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
+  1024,
+  "Singularity"
+);
+let ignitionBot = new CuratedProjectBot(
+  9000000,
+  "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
+  512,
+  "Ignition"
+);
+let squiggleBot = new CuratedProjectBot(
+  0,
+  "0x059edd72cd353df5106d2b9cc5ab83a52287ac3a",
+  10000,
+  "Chromie Squiggle"
+);
 let ringersBot = new CuratedProjectBot(
   13000000,
   "0xa7d8d9ef8d8ce8992df33d8b8cf4aebabd5bd270",
   1000,
   "Ringers"
-)
+);
 
 bot.on("message", (msg) => {
   if (msg.content.startsWith("#")) {
-    if (msg.channel.id === CHANNEL_SING) {
-      singData(msg, msg.content);
-    }
-    if (msg.channel.id === CHANNEL_IGNITION) {
-      ignition.ignitionData(msg, msg.content);
-    }
-    if (msg.channel.id === CHANNEL_SQUIG) {
-      squig.squigData(msg, msg.content);
-    }
-    if (msg.channel.id === CHANNEL_RINGERS) {
-      ringersBot.getData(msg, msg.content);
+    switch (msg.channel.id) {
+      case CHANNEL_SING:
+        singularityBot.getData(msg, msg.content);
+        break;
+      case CHANNEL_IGNITION:
+        ignitionBot.getData(msg, msg.content);
+        break;
+      case CHANNEL_SQUIG:
+        squiggleBot.getData(msg, msg.content);
+        break;
+      case CHANNEL_RINGERS:
+        ringersBot.getData(msg, msg.content);
+        break;
+      default:
+        console.log(`Unknown channel ID: ${msg.channel.id}`);
+        break;
     }
   }
 });

--- a/ringers.js
+++ b/ringers.js
@@ -25,8 +25,8 @@ async function metaData(data, msg, url) {
     .setColor(0xff0000)
     // Set the main content of the embed
     .setThumbnail(data.asset.image_url)
-    .addField("Features", `[view on artblocks.io](${abData.external_url})`)
-    .addField("Live Script", `${abData.features.join("\n")}`)
+    .addField("Live Script", `[view on artblocks.io](${abData.external_url})`)
+    .addField("Features", `${abData.features.join("\n")}`)
     // .addFields({
     //   name: "Features",
     //   value: featureData,


### PR DESCRIPTION
Migrate all existing curated project bots to use the new shared bot implementation.

A subsequent PR will delete the now obsolete code, but this PR migrates existing bots for Chromie Squiggles, Ingition, and Singularity to use the shared bot implementation added in #7.

In addition to improving code reuse and maintainability, this has had the added benefit of making bot results more consistent across projects:

<img width="606" alt="Screen Shot 2021-02-22 at 11 31 37 PM" src="https://user-images.githubusercontent.com/8602661/108809838-f0ae4980-7566-11eb-9d3a-7f2249e5421f.png">
<img width="601" alt="Screen Shot 2021-02-22 at 11 29 00 PM" src="https://user-images.githubusercontent.com/8602661/108809844-f2780d00-7566-11eb-828d-9b9aa72c8f67.png">
<img width="879" alt="Screen Shot 2021-02-22 at 11 22 16 PM" src="https://user-images.githubusercontent.com/8602661/108809852-f4da6700-7566-11eb-89c0-4636f00481c7.png">
