### PR TITLE
Add support for new random piece command.

### DIFF
--- a/CuratedProjectBot.js
+++ b/CuratedProjectBot.js
@@ -21,7 +21,21 @@ class CuratedProjectBot {
   }
 
   async getData(msg, number) {
-    let pieceNumber = parseInt(number.substring(1));
+    if (number.length <= 1) {
+      msg.channel.send(
+        `Invalid format, enter # followed by the piece number of interest.`
+      );
+      return;
+    }
+
+    let afterTheHash = number.substring(1);
+    let pieceNumber;
+    if (afterTheHash.toLowerCase() == "rand" || afterTheHash[0] == "?")  {
+      pieceNumber = parseInt(Math.random() * this.editionNumber);
+    } else {
+      pieceNumber = parseInt(afterTheHash);
+    }
+
     if (pieceNumber >= this.editionNumber || pieceNumber < 0) {
       msg.channel.send(
         `Invalid #, only ${this.editionNumber} pieces minted for ${this.projectName}.`


### PR DESCRIPTION
Add ability to query for a random piece by using #? or #RAND.

Lowercase and uppercase are supported: `#rand` and/or `#RAND`.

Additionally, any number of `?` characters are supported to trigger the same behavior: `#?` and/or `#?????`.

Screenshots of this in action:

<img width="862" alt="Screen Shot 2021-02-23 at 12 09 05 AM" src="https://user-images.githubusercontent.com/8602661/108812098-bb582a80-756b-11eb-852b-392c95a29876.png">
<img width="867" alt="Screen Shot 2021-02-23 at 12 06 19 AM" src="https://user-images.githubusercontent.com/8602661/108812102-bdba8480-756b-11eb-81ab-c59630f968bb.png">

This shouldn't be submitted until after #7.