### PR TITLE
Added a listings spammer to the ban list

### DIFF
--- a/Utils/activityTriager.js
+++ b/Utils/activityTriager.js
@@ -11,6 +11,7 @@ const CHANNEL_SQUIGGLE_SALES = process.env.CHANNEL_SQUIGGLE_SALES;
 // Addresses which should be omitted entirely from event feeds.
 const BAN_ADDRESSES = [
     "0x45d91f318b2abc6b569b6637c84cdb66486eb9ee",
+    "0x3c3fb7e51d8cfcc9451100dddf59255c6d7fc5c2",
     "0x7058634bc1394af83aa0a3589d6b818e4c35295a",
     "0x8491fc2625aeece9abc897ef29544e825a72d66e",
     "0xbcba11ef0dc585f028d8f4442e82ee6ceecbcbba",

--- a/Utils/activityTriager.js
+++ b/Utils/activityTriager.js
@@ -10,6 +10,7 @@ const CHANNEL_SQUIGGLE_SALES = process.env.CHANNEL_SQUIGGLE_SALES;
 
 // Addresses which should be omitted entirely from event feeds.
 const BAN_ADDRESSES = [
+    "0x45d91f318b2abc6b569b6637c84cdb66486eb9ee",
     "0x7058634bc1394af83aa0a3589d6b818e4c35295a",
     "0x8491fc2625aeece9abc897ef29544e825a72d66e",
     "0xbcba11ef0dc585f028d8f4442e82ee6ceecbcbba",


### PR DESCRIPTION
Added address of listings spammer - 0x45d91f318b2abc6b569b6637c84cdb66486eb9ee
Example spam: https://discord.com/channels/411959613370400778/830940204441272369/858336271716974603